### PR TITLE
Skip direnv if service account token already exists

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -37,8 +37,13 @@ fi
 
 ONE_PASSWORD_TOKEN="op://Pulumi/7pgmqbvpk6xaps4exrjgbjyy24/password"
 
-echo -e "Setting up 1Password CLI"
-export OP_SERVICE_ACCOUNT_TOKEN=$(op.exe read "${ONE_PASSWORD_TOKEN}")
+# Only authenticate with 1Password if not already authenticated
+if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+  echo -e "Setting up 1Password CLI"
+  export OP_SERVICE_ACCOUNT_TOKEN=$(op.exe read "${ONE_PASSWORD_TOKEN}")
+else
+  echo -e "1Password CLI already authenticated, using existing token"
+fi
 
 export GARMIN_USERNAME=$(op read "op://Pulumi/sso.garmin.com/username")
 export GARMIN_PASSWORD=$(op read "op://Pulumi/sso.garmin.com/password")


### PR DESCRIPTION
This makes it much more convenient to work with.