### PR TITLE
feat: make Claude Code review workflow comment-triggered

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,35 +1,29 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Only run on pull request comments that contain "@claude review"
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude review')
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          ref: refs/pull/${{ github.event.issue.number }}/head
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
## Summary
- Change Claude Code review workflow to only run when explicitly requested via comment
- Switch from automatic PR triggers to comment-based triggers with "@claude review"

## Test plan
- [ ] Test that workflow no longer runs automatically on new PRs
- [ ] Test that commenting "@claude review" on a PR triggers the workflow
- [ ] Verify Claude can write review comments with updated permissions

🤖 Generated with [Claude Code](https://claude.ai/code)