### PR TITLE
feat: add manual trigger and improve release workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     types: [closed, labeled]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_regenerate:
+        description: 'Force regenerate changelog'
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

This PR adds manual trigger capability to the changelog workflow and improves the release workflow by using git-cliff-action outputs.

## Key Changes

### 🔧 **Manual Changelog Trigger**
- Add  trigger to changelog workflow
- Enables manual changelog generation via GitHub Actions UI
- Solves the issue of triggering changelog for already-merged PRs
- Usage: Actions → Generate Changelog → Run workflow

### 🚀 **Release Workflow Improvements**  
- Use  instead of parsing pyproject.toml
- Combine version detection and release notes generation into single step
- Remove redundant file parsing logic
- Align with changelog workflow patterns for consistency

## Benefits

✅ **Manual Control**: Can now trigger changelog for historical PRs with labels  
✅ **More Reliable**: Eliminates potential version parsing errors  
✅ **Consistent**: Both workflows use same git-cliff-action pattern  
✅ **Simpler**: Fewer steps and dependencies  
✅ **Maintainable**: Leverages git-cliff-action outputs directly  

## Use Cases

- **Historical PRs**: Generate changelog when adding labels to old merged PRs
- **Force Regeneration**: Manual changelog updates when needed
- **Testing**: Validate workflow without waiting for PR events

## Test Plan

- [x] Workflow syntax validation passes
- [x] Manual trigger interface added
- [x] Release workflow simplified and improved
- [ ] Test manual trigger after merge
- [ ] Validate end-to-end changelog → release flow

🤖 Generated with [Claude Code](https://claude.ai/code)