### PR TITLE
refactor: remove labeled trigger since it doesn't work for merged PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,7 +2,7 @@ name: Generate Changelog
 
 on:
   pull_request:
-    types: [closed, labeled]
+    types: [closed]
     branches: [main]
   workflow_dispatch:
     inputs:
@@ -18,9 +18,7 @@ permissions:
 
 jobs:
   generate-changelog:
-    if: >
-      (github.event.action == 'closed' && github.event.pull_request.merged == true) ||
-      (github.event.action == 'labeled' && contains(fromJson('["breaking", "enhancement", "bug", "documentation", "security"]'), github.event.label.name))
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Remove the 'labeled' trigger and condition logic since GitHub doesn't
trigger labeled events on already-merged PRs. This reduces unnecessary
action runs and simplifies the workflow.

The workflow now only triggers on:
- PR merge (automatic)
- Manual dispatch (for historical PRs)

This is cleaner and more predictable behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>