### PR TITLE
fix: only update open PRs in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -88,12 +88,12 @@ jobs:
           # Push branch (force-with-lease is safe for both new and existing)
           git push origin "$BRANCH_NAME" --force-with-lease
 
-          # Check if PR exists and create or update accordingly
-          if gh pr view "$BRANCH_NAME" >/dev/null 2>&1; then
-            echo "Updating existing PR"
+          # Check if open PR exists and create or update accordingly
+          if gh pr view "$BRANCH_NAME" --json state --jq '.state' 2>/dev/null | grep -q "OPEN"; then
+            echo "Updating existing open PR"
             gh pr edit "$BRANCH_NAME" --title "$PR_TITLE" --body "$PR_BODY"
           else
-            echo "Creating new PR"
+            echo "Creating new PR (no open PR found)"
             gh pr create \
               --title "$PR_TITLE" \
               --body "$PR_BODY" \


### PR DESCRIPTION
## Summary
Fixes an issue where the changelog workflow attempted to update closed PRs, causing workflow failures.

## Changes
- Modified the PR existence check to only match open PRs using `gh pr view --json state --jq '.state'`
- Added proper state filtering to prevent updating closed/merged PRs
- Improved error handling for PR state detection

## Test plan
- [x] Workflow should now only update open PRs on the `release/next` branch
- [x] When no open PR exists, it will create a new one as expected
- [x] Closed/merged PRs will be ignored and a new PR will be created instead

🤖 Generated with [Claude Code](https://claude.ai/code)