### PR TITLE
Remove surplus empty line from changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -34,7 +34,6 @@ body = """
 {% for commit in commits %}
 * {{ commit.remote.pr_title | default(value=commit.message | split(pat="\n") | first) }} by @{{ commit.remote.username }} in [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }})
 {%- endfor %}
-
 {% endfor %}
 """
 # Remove leading and trailing whitespaces from the changelog's body.


### PR DESCRIPTION
This breaks end of file fixer.