### PR TITLE
fix: use --bump instead of --latest in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --latest --strip all
+          args: --bump --strip all
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Fixed release workflow creating releases named "null" instead of proper version numbers
- Removed malformed 'vnull' tag that was causing git-cliff version calculation issues
- Changed git-cliff args from `--latest` to `--bump` for proper initial version calculation

## Root Cause
The release workflow was using `git cliff --latest` which couldn't properly determine the version when starting from a repository with no valid tags. A malformed `vnull` tag was also interfering with version calculation.

## Solution
- Deleted the `vnull` tag locally and remotely
- Updated workflow to use `--bump` which properly uses the `initial_tag = "0.1.0"` from cliff.toml
- This ensures releases will be properly named "0.1.0" instead of "null"

## Test Plan
- [x] Verified git-cliff now generates version 0.1.0 locally
- [x] Confirmed malformed tag has been removed
- [ ] Test workflow on next release PR

🤖 Generated with [Claude Code](https://claude.ai/code)