### PR TITLE
fix: prevent double 'v' prefix in release workflow tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,14 @@ jobs:
         id: tag_check
         run: |
           VERSION="${{ steps.cliff.outputs.version }}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          # Remove any existing 'v' prefix to normalize the version
+          VERSION="${VERSION#v}"
+          TAG="v$VERSION"
 
-          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
           else
             echo "exists=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Normalize version string by removing existing 'v' prefix before adding one
- This prevents creating malformed tags like 'vv0.1.1' when git-cliff-action outputs version with 'v' prefix
- Cleaned up malformed `vv0.1.1` tag and replaced with correct `v0.1.1` tag

## Root Cause
The release workflow assumed git-cliff-action would output version numbers without the 'v' prefix, but sometimes it includes the prefix. This caused the workflow to create tags like `vv0.1.1` by prepending 'v' to an already prefixed version.

## Solution
- Use shell parameter expansion `${VERSION#v}` to strip any existing 'v' prefix
- Then consistently add the 'v' prefix to create the final tag name
- This ensures tags are always in the correct format `vX.Y.Z`

## Test plan
- [x] Verified git-cliff works correctly with proper tag format
- [x] Manually tested the shell parameter expansion logic
- [x] Cleaned up existing malformed tag from repository

🤖 Generated with [Claude Code](https://claude.ai/code)