### PR TITLE
fix: remove 'v' prefix from pyproject.toml version in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -45,9 +45,11 @@ jobs:
       - name: Update pyproject.toml version
         run: |
           # Update pyproject.toml with the new version from git-cliff
-          NEW_VERSION="${{ steps.changelog.outputs.version }}"
+          RAW_VERSION="${{ steps.changelog.outputs.version }}"
+          # Remove any 'v' prefix for pyproject.toml (Python packages should not have 'v' prefix)
+          NEW_VERSION="${RAW_VERSION#v}"
           sed -i "s/^version = .*/version = \"$NEW_VERSION\"/" pyproject.toml
-          echo "Updated version to $NEW_VERSION"
+          echo "Updated version to $NEW_VERSION (from $RAW_VERSION)"
 
       - name: Check for changes
         id: changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "strava-sensor"
-version = "v0.1.1"
+version = "0.1.1"
 description = "Strava Battery Sensor for Home Assistant"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
- Strip 'v' prefix from git-cliff version output before updating pyproject.toml
- Python package versions should not include 'v' prefix per PEP standards
- Update current pyproject.toml version to correct format without 'v' prefix

## Problem
The changelog workflow was directly using `{{ steps.changelog.outputs.version }}` from git-cliff-action to update pyproject.toml. When git-cliff outputs versions like "v0.1.1", this resulted in invalid Python package versions in pyproject.toml.

## Solution
- Use shell parameter expansion `${RAW_VERSION#v}` to strip any existing 'v' prefix
- Update pyproject.toml with clean semantic version (e.g., "0.1.1" instead of "v0.1.1")
- Add logging to show both raw and processed versions for transparency

## Test plan
- [x] Verified shell parameter expansion works correctly
- [x] Updated current pyproject.toml to correct format
- [x] Follows Python packaging standards (PEP 440)

🤖 Generated with [Claude Code](https://claude.ai/code)