### PR TITLE
fix: remove duplicate headers in GitHub release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --bump --strip all
+          args: --bump --strip header
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -84,10 +84,7 @@ jobs:
         with:
           tag_name: ${{ steps.tag_check.outputs.tag }}
           name: Release ${{ steps.tag_check.outputs.version }}
-          body: |
-            # Release ${{ steps.tag_check.outputs.version }}
-
-            ${{ steps.cliff.outputs.content }}
+          body: ${{ steps.cliff.outputs.content }}
           files: |
             dist/*.whl
             dist/*.tar.gz


### PR DESCRIPTION
## Summary
- Remove duplicate headers from GitHub release body
- Fix double header issue where releases showed both "# Changelog" and "# Release X.Y.Z"

## Problem
The release workflow was creating GitHub releases with duplicate headers:
1. Manual "# Release X.Y.Z" header added by the workflow
2. "# Changelog" header from git-cliff output

This resulted in messy release notes with redundant headers.

## Solution
- Change git-cliff action to use `--strip header` instead of `--strip all`
- Remove manual header addition in the release workflow body
- Let git-cliff provide the clean version header (e.g., "## [0.1.2] - 2025-08-15")

## Test plan
- [x] Verified `git cliff --bump --strip header` produces clean output without "# Changelog"
- [x] Workflow now uses git-cliff content directly without adding extra headers
- [x] Release body will have clean, single header format

🤖 Generated with [Claude Code](https://claude.ai/code)