### PR TITLE
feat: add semantic version bump detection script

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -32,12 +32,19 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
+      - name: Determine version bump type
+        id: bump_type
+        run: |
+          BUMP_TYPE=$(./scripts/determine-bump-type.sh)
+          echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+          echo "Determined bump type: $BUMP_TYPE"
+
       - name: Generate changelog and bump version
         id: changelog
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --bump
+          args: --bump ${{ steps.bump_type.outputs.bump_type }}
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           OUTPUT: CHANGELOG.md

--- a/scripts/determine-bump-type.sh
+++ b/scripts/determine-bump-type.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Script to determine semantic version bump type based on git cliff changelog groups
+# Outputs: major, minor, or patch to stdout
+# Logs debug information to stderr
+
+set -euo pipefail
+
+# Function to log to stderr
+log() {
+    echo "$@" >&2
+}
+
+# Main logic
+main() {
+    log "Running git cliff to generate unreleased changelog..."
+
+    # Get the unreleased changelog
+    local changelog
+    if ! changelog=$(git cliff --unreleased --strip all 2>/dev/null); then
+        log "Error: Failed to run git cliff"
+        exit 1
+    fi
+
+    # Check if there are any changes
+    if [[ -z "$changelog" || "$changelog" =~ ^[[:space:]]*$ ]]; then
+        log "No unreleased changes found"
+        echo "patch"  # Default to patch if no changes
+        exit 0
+    fi
+
+    log "Parsing changelog headers..."
+    log "Changelog content:"
+    log "$changelog"
+
+    # Extract level 3 headers (### ...)
+    local headers
+    headers=$(echo "$changelog" | grep '^### ' || true)
+
+    if [[ -z "$headers" ]]; then
+        log "No level 3 headers found, defaulting to patch"
+        echo "patch"
+        exit 0
+    fi
+
+    log "Found headers:"
+    log "$headers"
+
+    # Determine bump type based on header content
+    # Priority: Breaking > Enhancement > Everything else (patch)
+
+    if echo "$headers" | grep -q "🚨 Breaking Changes"; then
+        log "Found breaking changes - bumping major version"
+        echo "major"
+    elif echo "$headers" | grep -q "✨ Enhancements"; then
+        log "Found enhancements - bumping minor version"
+        echo "minor"
+    else
+        log "Found other changes (security, bug fixes, docs, etc.) - bumping patch version"
+        echo "patch"
+    fi
+}
+
+# Execute main function
+main "$@"


### PR DESCRIPTION
## Summary
- Add `scripts/determine-bump-type.sh` to analyze git cliff changelog groups and determine appropriate semantic version bump type
- Update changelog workflow to use custom bump detection instead of `git-cliff --bump`
- Fixes issue where `git-cliff --bump` doesn't work with PR-based changelog configurations

## Implementation Details
The script:
1. Runs `git cliff --unreleased --strip all` to get unreleased changes
2. Parses level 3 markdown headers (`### ...`) from the changelog
3. Determines bump type with priority: Breaking Changes → Enhancements → Other (patch)
4. Outputs exactly one word (`major`, `minor`, or `patch`) to stdout
5. Logs debug information to stderr

## Test plan
- [x] Script correctly identifies breaking changes and returns `major`
- [x] Script handles edge cases (no changes, parsing errors)  
- [x] Workflow updated to use script output with git-cliff
- [ ] Test in CI workflow when PR is merged

🤖 Generated with [Claude Code](https://claude.ai/code)