### PR TITLE
fix: install git-cliff before running bump detection script

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -32,6 +32,14 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
+      - name: Install git-cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --version
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+
       - name: Determine version bump type
         id: bump_type
         run: |


### PR DESCRIPTION
## Summary
- Add git-cliff installation step before running `determine-bump-type.sh`
- Fixes CI error where `git cliff` command was not found in the workflow

## Issue
The `determine-bump-type.sh` script calls `git cliff --unreleased --strip all` but git-cliff wasn't installed yet in the workflow, causing the script to fail.

## Solution
Added a step to install git-cliff using the `orhun/git-cliff-action@v4` before running our custom bump detection script.

## Test plan
- [x] Workflow should now successfully run the bump detection script
- [ ] Verify in CI that git-cliff is available when script runs

Fixes the workflow error in PR #57.

🤖 Generated with [Claude Code](https://claude.ai/code)