### PR TITLE
fix: use setup-git-cliff for proper git-cliff installation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -33,12 +33,7 @@ jobs:
           git config --local user.name "GitHub Action"
 
       - name: Install git-cliff
-        uses: orhun/git-cliff-action@v4
-        with:
-          config: cliff.toml
-          args: --version
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+        uses: kenji-miyake/setup-git-cliff@v1
 
       - name: Determine version bump type
         id: bump_type


### PR DESCRIPTION
## Summary
- Use `kenji-miyake/setup-git-cliff@v1` instead of the git-cliff-action for installation
- This properly installs git-cliff binary in PATH for subsequent workflow steps
- Fixes CI error where git-cliff command was not available for the bump detection script

## Issue
The previous approach using `orhun/git-cliff-action` only made git-cliff available within that action's context, not for subsequent shell script steps.

## Solution
Use `kenji-miyake/setup-git-cliff@v1` which properly installs git-cliff as a binary that can be used in later workflow steps.

## Test plan
- [ ] Workflow should successfully run the bump detection script without git-cliff errors
- [ ] Verify git-cliff is available when `determine-bump-type.sh` runs

Supersedes PR #58 with a better solution.

🤖 Generated with [Claude Code](https://claude.ai/code)