### PR TITLE
fix: update release workflow to use proper semantic versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,22 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
+      - name: Install git-cliff
+        uses: kenji-miyake/setup-git-cliff@v1
+
+      - name: Determine version bump type
+        id: bump_type
+        run: |
+          BUMP_TYPE=$(./scripts/determine-bump-type.sh)
+          echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+          echo "Determined bump type: $BUMP_TYPE"
+
       - name: Get version and generate release notes
         id: cliff
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --bump --unreleased --strip header
+          args: --bump ${{ steps.bump_type.outputs.bump_type }} --unreleased --strip header
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Add setup-git-cliff installation to release workflow
- Use `determine-bump-type.sh` script to determine correct semantic version bump
- Pass explicit bump type to git-cliff instead of using `--bump` alone
- Fixes issue where wrong version tags were created

## Issue
The release workflow was using `git-cliff --bump` which doesn't work properly with PR-based changelog configurations, resulting in incorrect version tags like `v0.1.5` instead of the expected `v1.0.0` for breaking changes.

## Solution
Apply the same pattern as the changelog workflow:
1. Install git-cliff using `kenji-miyake/setup-git-cliff@v1`
2. Run `determine-bump-type.sh` to analyze PR labels and determine correct bump type
3. Pass the determined bump type to git-cliff explicitly: `--bump major/minor/patch`

## Test plan
- [ ] Next release should create the correct version tag based on PR labels
- [ ] Breaking changes should result in major version bump
- [ ] Enhancements should result in minor version bump
- [ ] Bug fixes/docs should result in patch version bump

This ensures consistent semantic versioning across both changelog generation and release creation.

🤖 Generated with [Claude Code](https://claude.ai/code)