### PR TITLE
fix: sync uv.lock with version bump in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -52,6 +52,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           OUTPUT: CHANGELOG.md
 
+      - name: Set up Python and uv
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Update pyproject.toml version
         run: |
           # Update pyproject.toml with the new version from git-cliff
@@ -60,6 +68,12 @@ jobs:
           NEW_VERSION="${RAW_VERSION#v}"
           sed -i "s/^version = .*/version = \"$NEW_VERSION\"/" pyproject.toml
           echo "Updated version to $NEW_VERSION (from $RAW_VERSION)"
+
+      - name: Update uv.lock with new version
+        run: |
+          # Sync lock file to update project version
+          uv sync
+          echo "Updated uv.lock with new project version"
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
## Summary

Fixes a bug where `uv.lock` becomes out of sync with `pyproject.toml` after release version bumps.

## Problem

When the changelog workflow creates a new release:
1. `git-cliff` determines the new version 
2. `pyproject.toml` gets updated with the new version
3. ⚠️ `uv.lock` still contains the old project version
4. This creates version inconsistency between the two files

## Solution

Added Python/uv setup and a sync step to the changelog workflow:
- Install Python 3.13 and uv before version updates
- Run `uv sync` after updating `pyproject.toml` to refresh the lock file
- Ensures both files are committed with consistent versions

## Test plan

- [x] Workflow file passes yamllint validation
- [ ] Test on next release to verify `uv.lock` gets updated correctly
- [ ] Verify both files show same version after release preparation

🤖 Generated with [Claude Code](https://claude.ai/code)