### PR TITLE
fix: convert Docker repository name to lowercase

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   docker-build:
@@ -21,6 +20,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      - name: Generate lowercase image name
+        id: image
+        run: echo "name=$(echo ${{ env.REGISTRY }}/${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
@@ -34,7 +37,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ steps.image.outputs.name }}
           tags: |
             # set latest tag for main branch
             type=raw,value=latest,enable={{is_default_branch}}


### PR DESCRIPTION
## Summary

- Fixes Docker build error: "repository name must be lowercase"
- Adds step to generate lowercase version of repository name using `tr` command
- Updates metadata action to use lowercase image name

## Problem

The Docker workflow was failing because `${{ github.repository }}` contains uppercase letters in "CrashLoopBackCoffee/th-strava-sensor", but Docker requires repository names to be lowercase.

## Solution

Added a new step that converts the repository name to lowercase:
```yaml
- name: Generate lowercase image name
  id: image
  run: echo "name=$(echo ${{ env.REGISTRY }}/${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
```

Then uses this lowercase name in the metadata action instead of the original repository name.

## Test plan

- [ ] Verify Docker workflow runs successfully without lowercase errors
- [ ] Confirm Docker images are tagged correctly with lowercase repository name

🤖 Generated with [Claude Code](https://claude.ai/code)