### PR TITLE
fix: convert Docker repository name to lowercase in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,11 @@ jobs:
           draft: false
           prerelease: false
 
+      - name: Generate lowercase image name
+        if: steps.tag_check.outputs.exists == 'false'
+        id: image
+        run: echo "name=$(echo ghcr.io/${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
       - name: Log in to Container Registry
         if: steps.tag_check.outputs.exists == 'false'
         uses: docker/login-action@v3
@@ -117,8 +122,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.tag_check.outputs.version }}
-            ghcr.io/${{ github.repository }}:latest
+            ${{ steps.image.outputs.name }}:${{ steps.tag_check.outputs.version }}
+            ${{ steps.image.outputs.name }}:latest
           build-args: |
             UV_VERSION=0.8.11
 


### PR DESCRIPTION
## Summary

- Fixes Docker build error in release workflow: "repository name must be lowercase"
- Adds step to generate lowercase version of repository name using `tr` command
- Updates Docker tags to use lowercase image name

## Problem

The release workflow was also failing with the same Docker error because it uses `ghcr.io/${{ github.repository }}` directly for Docker tags, which contains uppercase letters in "CrashLoopBackCoffee/th-strava-sensor".

## Solution

Applied the same fix as in the Docker workflow by:
1. Adding a step to generate lowercase image name
2. Using this lowercase name in the Docker build and push action

This ensures both the regular Docker workflow and release workflow use lowercase repository names.

## Test plan

- [ ] Verify release workflow runs successfully without Docker lowercase errors
- [ ] Confirm release Docker images are tagged correctly with lowercase repository name

🤖 Generated with [Claude Code](https://claude.ai/code)