### PR TITLE
Expose UV_VERSION env in Docker workflow (Renovate metadata, value unchanged)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  # renovate: datasource=github-releases depName=astral-sh/uv
+  UV_VERSION: 0.8.11
 
 jobs:
   docker-build:
@@ -50,4 +52,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            UV_VERSION=0.8.11
+            UV_VERSION=${{ env.UV_VERSION }}


### PR DESCRIPTION
### Motivation
- Make the UV dependency manageable by Renovate by exposing a top-level `UV_VERSION` environment variable annotated with Renovate metadata so Renovate can track releases.

### Description
- Add the `# renovate: datasource=github-releases depName=astral-sh/uv` comment and expose `UV_VERSION` in `.github/workflows/docker.yml` env and switch the Docker `build-args` to `UV_VERSION=${{ env.UV_VERSION }}` instead of a hardcoded value while keeping the current `UV_VERSION` value unchanged.

### Testing
- No automated tests were run because this is a workflow-only change affecting GitHub Actions configuration only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986f4aa2064832c8fb97de0000cf45d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration by externalizing version management for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->