### PR TITLE
chore(ci): use setup-project action in workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -52,13 +52,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           OUTPUT: CHANGELOG.md
 
-      - name: Set up Python and uv
-        uses: actions/setup-python@v6
+      - name: Setup project
+        uses: ./.github/actions/setup-project
         with:
           python-version: "3.13"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
 
       - name: Update pyproject.toml version
         run: |

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -14,18 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+      - name: Setup project
+        uses: ./.github/actions/setup-project
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Install dependencies
+      - name: Upgrade pip and install poetry
         run: |
           python -m pip install --upgrade pip poetry
-          uv sync
 
       - name: Running linters
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Setup project
+        uses: ./.github/actions/setup-project
         with:
           python-version: "3.13"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
 
       - name: Install git-cliff
         uses: kenji-miyake/setup-git-cliff@v2
@@ -78,9 +75,6 @@ jobs:
       - name: Build artifacts
         if: steps.tag_check.outputs.exists == 'false'
         run: |
-          # Install dependencies and build package
-          uv sync
-
           # Build wheel and sdist
           uv build
 


### PR DESCRIPTION
### Motivation
- Centralize Python and UV environment setup across workflows by reusing the repository-local `./.github/actions/setup-project` action. 
- Ensure the linters job still has `pip` and `poetry` available after switching to the shared setup, addressing the missing-install inline comment.

### Description
- Replaced `actions/setup-python` and `astral-sh/setup-uv` with `./.github/actions/setup-project` in `.github/workflows/linters.yml`, `.github/workflows/changelog.yml`, and `.github/workflows/release.yml`.
- Restored an explicit linters step that runs `python -m pip install --upgrade pip poetry` to ensure `poetry` is available for lint/test tasks and removed the redundant `uv sync` from that job.
- Removed the explicit `uv sync` from the release build step because the reusable `setup-project` already performs dependency sync, and kept the `uv sync` call in the changelog job where it updates `uv.lock` after bumping the version.

### Testing
- Ran `uv run ./scripts/run-all-checks.sh`, which failed due to `pre-commit` attempting to fetch external hooks and being blocked by network restrictions (`CONNECT tunnel failed, response 403`).
- No GitHub Actions CI runs were executed locally; the workflow behavior should be validated by CI on GitHub.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698703d24f18832c8174ebc7c467e697)