### PR TITLE
Fix strava webhook registration

### DIFF
--- a/src/strava_sensor/webhook_server.py
+++ b/src/strava_sensor/webhook_server.py
@@ -26,18 +26,18 @@ _logger = logging.getLogger(__name__)
 
 async def _register_webhook():
     """Register the Strava webhook subscription on startup."""
-
-    _logger.info('Wait to register Strava webhook subscription')
-    # Wait for 2 seconds to give the server time to start
-    await asyncio.sleep(2)
-
-    # Ensure subscription AFTER server is listening to avoid Strava verification race.
-    _logger.info('Registering Strava webhook subscription')
-    # Call async variant directly (avoid sync wrapper which uses asyncio.run())
-    sub_id = await manager_singleton.ensure_subscription()
-    if manager_singleton.verify_token and not os.environ.get('STRAVA_VERIFY_TOKEN'):
-        _logger.info('Using generated STRAVA_VERIFY_TOKEN=%s', manager_singleton.verify_token)
-    _logger.info('Active Strava subscription id=%s', sub_id)
+    try:
+        _logger.info('Registering Strava webhook subscription')
+        # Call async variant directly (avoid sync wrapper which uses asyncio.run())
+        sub_id = await manager_singleton.ensure_subscription()
+        if manager_singleton.verify_token and not os.environ.get('STRAVA_VERIFY_TOKEN'):
+            _logger.info('Using generated STRAVA_VERIFY_TOKEN=%s', manager_singleton.verify_token)
+        _logger.info('Active Strava subscription id=%s', sub_id)
+    except asyncio.CancelledError:
+        _logger.info('Webhook registration task cancelled')
+        raise
+    except Exception:
+        _logger.exception('Failed to register Strava webhook subscription')
 
 
 async def _delete_webhook():
@@ -47,6 +47,7 @@ async def _delete_webhook():
 
 class _State:
     mqtt_client: MQTTClient | None = None
+    webhook_registration_task: asyncio.Task[None] | None = None
 
 
 _state = _State()
@@ -63,9 +64,6 @@ async def lifespan(app: fastapi.FastAPI):
         error_msg = f'Missing required environment variables: {", ".join(missing_vars)}'
         _logger.error(error_msg)
         raise RuntimeError(error_msg)
-
-    # Register webhook and wait for completion to handle errors properly
-    await _register_webhook()
 
     # Initialize persistent MQTT client if env vars provided
     # persistent MQTT client lives on _state
@@ -92,8 +90,22 @@ async def lifespan(app: fastapi.FastAPI):
         except Exception:  # don't fail whole app; log
             _logger.exception('Failed to start persistent MQTT client')
             _state.mqtt_client = None
+
+    # Register webhook in background so startup can complete and Strava can verify callback URL.
+    _state.webhook_registration_task = asyncio.create_task(
+        _register_webhook(),
+        name='strava-webhook-registration',
+    )
     yield
+
     # Shutdown sequence
+    if _state.webhook_registration_task:
+        if not _state.webhook_registration_task.done():
+            _state.webhook_registration_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await _state.webhook_registration_task
+        _state.webhook_registration_task = None
+
     if _state.mqtt_client:
         try:
             _state.mqtt_client.disconnect()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from unittest import mock
 
 import pytest
@@ -5,8 +7,8 @@ import requests
 
 from fastapi.testclient import TestClient
 
+from strava_sensor import webhook_server
 from strava_sensor.strava.webhook import StravaWebhookManager
-from strava_sensor.webhook_server import app
 
 
 class MockResponse:
@@ -53,7 +55,7 @@ class MockHttpClient:
 
 @pytest.fixture
 def webhook_client():
-    return TestClient(app)
+    return TestClient(webhook_server.app)
 
 
 @pytest.fixture
@@ -200,3 +202,30 @@ async def test_retry_create_fail(strava_webhook_env, monkeypatch):
     with mock.patch('httpx.AsyncClient', lambda *_args, **_kwargs: mock_client):
         with pytest.raises(RuntimeError):
             await mgr.ensure_subscription()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_does_not_block_on_webhook_registration(strava_webhook_env, monkeypatch):
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def fake_register_webhook():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    async def fake_delete_webhook():
+        return None
+
+    monkeypatch.setattr(webhook_server, '_register_webhook', fake_register_webhook)
+    monkeypatch.setattr(webhook_server, '_delete_webhook', fake_delete_webhook)
+
+    async def _run_lifespan_once():
+        async with webhook_server.lifespan(webhook_server.app):
+            await asyncio.wait_for(started.wait(), timeout=0.2)
+
+    await asyncio.wait_for(_run_lifespan_once(), timeout=0.5)
+    assert cancelled.is_set()


### PR DESCRIPTION
We cannot await the webhook registration in the lifespan as this
blocks app startup which is required so strava can call back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Webhook registration now proceeds asynchronously in the background, allowing the server to start immediately rather than waiting for registration to complete.
  * Added proper cleanup of webhook registration tasks during server shutdown.

* **Tests**
  * Added test to verify webhook registration does not block the server startup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->