### PR TITLE
Align webhook server logging format (reuse existing logging config)

### DIFF
--- a/src/strava_sensor/webhook_server.py
+++ b/src/strava_sensor/webhook_server.py
@@ -376,7 +376,7 @@ def main() -> None:  # entry point
     port = int(os.environ.get('WEBHOOK_PORT', '8000'))
     _logger.info('Starting webhook server on http://localhost:%s', port)
     # Prefer websockets-sansio to avoid deprecated legacy protocol imports.
-    uvicorn.run(app, host='0.0.0.0', port=port, ws='websockets-sansio')
+    uvicorn.run(app, host='0.0.0.0', port=port, ws='websockets-sansio', log_config=None)
 
 
 register_status_page(


### PR DESCRIPTION
### Motivation
- Uvicorn/NiceGUI was initializing its own logging configuration which produced access logs in a different format than the rest of the application, so the server should reuse the project's logging setup.

### Description
- Pass `log_config=None` to `uvicorn.run()` in `src/strava_sensor/webhook_server.py` so uvicorn does not reconfigure logging and access logs match the project's format.

### Testing
- Ran `uv run ./scripts/run-all-checks.sh` and the checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987946a7aa4832cb131249f3bda669c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted webhook server logging configuration to reduce startup overhead and prevent default logging initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->