### PR TITLE
Remember all sensors in local state

### DIFF
--- a/src/strava_sensor/last_activity_store.py
+++ b/src/strava_sensor/last_activity_store.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import pathlib
+import typing as t
 
 import pydantic
 
@@ -14,9 +15,19 @@ _DEFAULT_LAST_ACTIVITY_METADATA_PATH = '.strava_sensor_last_activity.json'
 
 
 class LastActivityMetadata(pydantic.BaseModel):
+    """Legacy persisted schema retained for backwards compatibility."""
+
     activity_id: int
     recorded_at: datetime.datetime
     devices: list[DeviceStatus]
+
+
+class PersistedSensorState(pydantic.BaseModel):
+    updated_at: datetime.datetime
+    devices: list[DeviceStatus]
+    last_activity_id: int | None = None
+    last_activity_recorded_at: datetime.datetime | None = None
+    last_activity_device_serials: list[str] = pydantic.Field(default_factory=list)
 
 
 class LastActivityStore:
@@ -32,10 +43,16 @@ class LastActivityStore:
         return cls(pathlib.Path(configured_path).expanduser())
 
     def save(self, activity_id: int, devices: list[DeviceStatus]) -> None:
-        metadata = LastActivityMetadata(
-            activity_id=activity_id,
-            recorded_at=datetime.datetime.now(datetime.UTC),
-            devices=devices,
+        existing = self.load()
+        merged_devices = self._merge_devices(existing.devices if existing else [], devices)
+        now = datetime.datetime.now(datetime.UTC)
+
+        metadata = PersistedSensorState(
+            updated_at=now,
+            devices=merged_devices,
+            last_activity_id=activity_id,
+            last_activity_recorded_at=now,
+            last_activity_device_serials=sorted({str(device.serial_number) for device in devices}),
         )
         payload = metadata.model_dump(mode='json')
 
@@ -45,20 +62,49 @@ class LastActivityStore:
             tmp_path.write_text(json.dumps(payload), encoding='utf-8')
             tmp_path.replace(self.path)
         except OSError:
-            _logger.exception('Failed to persist activity metadata to %s', self.path)
+            _logger.exception('Failed to persist sensor state to %s', self.path)
 
-    def load(self) -> LastActivityMetadata | None:
+    def load(self) -> PersistedSensorState | None:
         if not self.path.exists():
             return None
 
         try:
             payload = json.loads(self.path.read_text(encoding='utf-8'))
         except (OSError, json.JSONDecodeError):
-            _logger.exception('Failed to read persisted activity metadata from %s', self.path)
+            _logger.exception('Failed to read persisted sensor state from %s', self.path)
             return None
 
+        persisted_state = self._validate_state_payload(payload)
+        if persisted_state is not None:
+            return persisted_state
+
+        _logger.error('Persisted sensor state in %s is invalid', self.path)
+        return None
+
+    @staticmethod
+    def _merge_devices(
+        existing_devices: list[DeviceStatus], incoming_devices: list[DeviceStatus]
+    ) -> list[DeviceStatus]:
+        merged: dict[str, DeviceStatus] = {
+            str(device.serial_number): device for device in existing_devices
+        }
+        for device in incoming_devices:
+            merged[str(device.serial_number)] = device
+        return [merged[key] for key in sorted(merged)]
+
+    @staticmethod
+    def _validate_state_payload(payload: t.Any) -> PersistedSensorState | None:
         try:
-            return LastActivityMetadata.model_validate(payload)
+            return PersistedSensorState.model_validate(payload)
         except pydantic.ValidationError:
-            _logger.exception('Persisted activity metadata in %s is invalid', self.path)
+            pass
+
+        try:
+            legacy = LastActivityMetadata.model_validate(payload)
+        except pydantic.ValidationError:
             return None
+
+        return PersistedSensorState(
+            updated_at=legacy.recorded_at,
+            devices=legacy.devices,
+        )

--- a/src/strava_sensor/ui/status_page.py
+++ b/src/strava_sensor/ui/status_page.py
@@ -8,7 +8,7 @@ import fastapi
 from nicegui import events, ui
 
 from strava_sensor.fitfile.model import DeviceStatus
-from strava_sensor.last_activity_store import LastActivityMetadata
+from strava_sensor.last_activity_store import PersistedSensorState
 from strava_sensor.runtime_state import runtime_state
 from strava_sensor.strava.webhook import manager_singleton
 
@@ -49,6 +49,8 @@ class PersistedDeviceView:
     battery_level: str
     battery_status: str
     battery_voltage: str
+    last_activity_marker: str
+    last_activity_marker_color: str
     serial_number: str
     manufacturer: str
     product: str
@@ -60,9 +62,9 @@ class PersistedDeviceView:
 class StatusViewModel:
     def __init__(
         self,
-        last_activity_loader: t.Callable[[], LastActivityMetadata | None] | None = None,
+        persisted_sensor_loader: t.Callable[[], PersistedSensorState | None] | None = None,
     ) -> None:
-        self._last_activity_loader = last_activity_loader
+        self._persisted_sensor_loader = persisted_sensor_loader
         self.subscription_id = '—'
         self.webhook_url = '—'
         self.webhook_error = '—'
@@ -77,10 +79,11 @@ class StatusViewModel:
         self.last_activity_time = '—'
         self.last_fit_error_message = '—'
         self.last_fit_error_time = '—'
-        self.last_persisted_activity_id = '—'
-        self.last_persisted_recorded_at = '—'
-        self.last_persisted_device_count = '—'
-        self.last_persisted_devices: list[PersistedDeviceView] = []
+        self.persisted_sensor_updated_at = '—'
+        self.persisted_sensor_count = '—'
+        self.persisted_last_activity_id = '—'
+        self.persisted_last_activity_time = '—'
+        self.persisted_sensors: list[PersistedDeviceView] = []
         self.env_strava_client_id = 'missing'
         self.env_strava_client_secret = 'missing'
         self.env_strava_webhook_url = 'missing'
@@ -159,40 +162,54 @@ class StatusViewModel:
         self.env_mqtt_broker_url = _env_value('MQTT_BROKER_URL')
         self.env_mqtt_username = _env_value('MQTT_USERNAME')
         self.env_mqtt_password = _env_value('MQTT_PASSWORD')
-        self._update_last_activity_metadata()
+        self._update_persisted_sensor_state()
 
-    def _update_last_activity_metadata(self) -> None:
-        if self._last_activity_loader is None:
-            self.last_persisted_activity_id = '—'
-            self.last_persisted_recorded_at = '—'
-            self.last_persisted_device_count = '—'
-            self.last_persisted_devices = []
+    def _update_persisted_sensor_state(self) -> None:
+        if self._persisted_sensor_loader is None:
+            self.persisted_sensor_updated_at = '—'
+            self.persisted_sensor_count = '—'
+            self.persisted_last_activity_id = '—'
+            self.persisted_last_activity_time = '—'
+            self.persisted_sensors = []
             return
 
-        metadata = self._last_activity_loader()
+        metadata = self._persisted_sensor_loader()
         if not metadata:
-            self.last_persisted_activity_id = '—'
-            self.last_persisted_recorded_at = '—'
-            self.last_persisted_device_count = '—'
-            self.last_persisted_devices = []
+            self.persisted_sensor_updated_at = '—'
+            self.persisted_sensor_count = '—'
+            self.persisted_last_activity_id = '—'
+            self.persisted_last_activity_time = '—'
+            self.persisted_sensors = []
             return
 
-        self.last_persisted_activity_id = str(metadata.activity_id)
-        self.last_persisted_recorded_at = _format_time(metadata.recorded_at)
-        self.last_persisted_device_count = str(len(metadata.devices))
-        self.last_persisted_devices = self._format_devices(metadata.devices)
+        self.persisted_sensor_updated_at = _format_time(metadata.updated_at)
+        self.persisted_sensor_count = str(len(metadata.devices))
+        self.persisted_last_activity_id = (
+            str(metadata.last_activity_id) if metadata.last_activity_id is not None else '—'
+        )
+        self.persisted_last_activity_time = _format_time(metadata.last_activity_recorded_at)
+        last_activity_serials = set(metadata.last_activity_device_serials)
+        self.persisted_sensors = self._format_devices(metadata.devices, last_activity_serials)
 
     @staticmethod
-    def _format_devices(devices: list[DeviceStatus]) -> list[PersistedDeviceView]:
+    def _format_devices(
+        devices: list[DeviceStatus], last_activity_serials: set[str]
+    ) -> list[PersistedDeviceView]:
         views: list[PersistedDeviceView] = []
         for device in devices:
+            serial = str(device.serial_number)
+            is_from_last_activity = serial in last_activity_serials
             views.append(
                 PersistedDeviceView(
                     title=f'#{device.device_index} {_pretty_name(device.device_type)}',
                     battery_level=_format_battery_level(device.battery_level),
                     battery_status=str(device.battery_status),
                     battery_voltage=_format_voltage(device.battery_voltage),
-                    serial_number=str(device.serial_number),
+                    last_activity_marker=(
+                        'last activity' if is_from_last_activity else 'known (older)'
+                    ),
+                    last_activity_marker_color='positive' if is_from_last_activity else 'grey',
+                    serial_number=serial,
                     manufacturer=_pretty_name(device.manufacturer),
                     product=device.product,
                     source_type=_pretty_name(device.source_type),
@@ -208,7 +225,7 @@ def register_status_page(
     mqtt_disconnect_action: t.Callable[[], t.Awaitable[dict[str, t.Any]]] | None = None,
     mqtt_reconnect_action: t.Callable[[], t.Awaitable[dict[str, t.Any]]] | None = None,
     fit_upload_action: t.Callable[[str, bytes], t.Awaitable[dict[str, t.Any]]] | None = None,
-    last_activity_loader: t.Callable[[], LastActivityMetadata | None] | None = None,
+    persisted_sensor_loader: t.Callable[[], PersistedSensorState | None] | None = None,
 ) -> None:
     @app.get('/status')
     def status_redirect() -> fastapi.responses.RedirectResponse:
@@ -216,7 +233,7 @@ def register_status_page(
 
     @ui.page('/')
     def status_page() -> None:
-        model = StatusViewModel(last_activity_loader=last_activity_loader)
+        model = StatusViewModel(persisted_sensor_loader=persisted_sensor_loader)
         device_cards_container: t.Any | None = None
         fit_upload_input: t.Any | None = None
         ui.add_head_html(
@@ -384,21 +401,25 @@ def register_status_page(
         def _render_persisted_devices(container: t.Any) -> None:
             container.clear()
             with container:
-                if not model.last_persisted_devices:
+                if not model.persisted_sensors:
                     ui.label('No persisted device status available yet.').classes(
                         'text-sm text-slate-500'
                     )
                     return
 
-                for device in model.last_persisted_devices:
+                for device in model.persisted_sensors:
                     with ui.card().classes('status-device-card w-full'):
                         with ui.row().classes(
                             'w-full items-center justify-between gap-2 flex-wrap'
                         ):
                             ui.label(device.title).classes('text-base font-semibold text-slate-900')
-                            ui.badge(f'{device.battery_level} ({device.battery_status})').props(
-                                f'color={_battery_status_color(device.battery_status)}'
-                            ).classes('text-xs px-3 py-1 rounded-full font-semibold')
+                            with ui.row().classes('items-center gap-2'):
+                                ui.badge(device.last_activity_marker).props(
+                                    f'color={device.last_activity_marker_color}'
+                                ).classes('text-xs px-3 py-1 rounded-full font-semibold')
+                                ui.badge(f'{device.battery_level} ({device.battery_status})').props(
+                                    f'color={_battery_status_color(device.battery_status)}'
+                                ).classes('text-xs px-3 py-1 rounded-full font-semibold')
                         with ui.element('div').classes('status-device-grid'):
                             _render_device_value('Serial', device.serial_number)
                             _render_device_value(
@@ -454,18 +475,23 @@ def register_status_page(
                 _render_field('Last FIT Error', 'last_fit_error_message')
                 _render_field('Error Time', 'last_fit_error_time', monospace=True)
                 _render_field(
-                    'Persisted Activity ID',
-                    'last_persisted_activity_id',
+                    'Persisted Sensors Updated At',
+                    'persisted_sensor_updated_at',
                     monospace=True,
                 )
                 _render_field(
-                    'Persisted At',
-                    'last_persisted_recorded_at',
+                    'Persisted Sensor Count',
+                    'persisted_sensor_count',
                     monospace=True,
                 )
                 _render_field(
-                    'Device Count',
-                    'last_persisted_device_count',
+                    'Persisted Last Activity ID',
+                    'persisted_last_activity_id',
+                    monospace=True,
+                )
+                _render_field(
+                    'Persisted Last Activity Time',
+                    'persisted_last_activity_time',
                     monospace=True,
                 )
                 ui.label('Devices').classes('status-key pt-3')

--- a/src/strava_sensor/webhook_server.py
+++ b/src/strava_sensor/webhook_server.py
@@ -95,28 +95,26 @@ def _mqtt_env_is_configured() -> bool:
     return all(os.environ.get(name) for name in _MQTT_ENV_VARS)
 
 
-def _persist_last_activity_metadata(activity_id: int, devices_status: list[DeviceStatus]) -> None:
+def _persist_sensor_state(activity_id: int, devices_status: list[DeviceStatus]) -> None:
     _last_activity_store.save(activity_id, devices_status)
 
 
-def _republish_last_activity_metadata(mqtt_client: MQTTClient) -> None:
-    last_activity = _last_activity_store.load()
-    if not last_activity:
-        _logger.debug('No persisted activity metadata found to republish')
+def _republish_persisted_sensor_state(mqtt_client: MQTTClient) -> None:
+    persisted_state = _last_activity_store.load()
+    if not persisted_state:
+        _logger.debug('No persisted sensor state found to republish')
         return
-    if not last_activity.devices:
+    if not persisted_state.devices:
         _logger.info(
-            'Persisted activity metadata for activity %s has no devices to republish',
-            last_activity.activity_id,
+            'Persisted sensor state has no devices to republish',
         )
         return
 
     _logger.info(
-        'Republishing %s persisted device statuses from activity %s',
-        len(last_activity.devices),
-        last_activity.activity_id,
+        'Republishing %s persisted device statuses',
+        len(persisted_state.devices),
     )
-    for device_status in last_activity.devices:
+    for device_status in persisted_state.devices:
         success = device_status.publish_on_mqtt(mqtt_client)
         runtime_state.record_mqtt_publish(str(device_status.serial_number), success)
         if not success:
@@ -129,9 +127,9 @@ def _republish_last_activity_metadata(mqtt_client: MQTTClient) -> None:
 def _on_mqtt_connect(mqtt_client: MQTTClient) -> None:
     runtime_state.set_mqtt_connected(True)
     try:
-        _republish_last_activity_metadata(mqtt_client)
+        _republish_persisted_sensor_state(mqtt_client)
     except Exception:
-        _logger.exception('Failed to republish persisted activity metadata on MQTT connect')
+        _logger.exception('Failed to republish persisted sensor state on MQTT connect')
 
 
 async def _sync_mqtt_state() -> None:
@@ -173,7 +171,7 @@ async def _process_fit_bytes_async(
     _logger.debug('Parsed FIT file for activity %s', activity_id)
 
     devices_status = fitfile.get_devices_status()
-    _persist_last_activity_metadata(activity_id, devices_status)
+    _persist_sensor_state(activity_id, devices_status)
     await _sync_mqtt_state()
 
     if not devices_status:
@@ -429,7 +427,7 @@ register_status_page(
     mqtt_disconnect_action=_disconnect_mqtt_client,
     mqtt_reconnect_action=_reconnect_mqtt_client,
     fit_upload_action=_process_manual_fit_upload,
-    last_activity_loader=_last_activity_store.load,
+    persisted_sensor_loader=_last_activity_store.load,
 )
 
 

--- a/tests/test_last_activity_store.py
+++ b/tests/test_last_activity_store.py
@@ -1,7 +1,8 @@
+import datetime
 import json
 
 from strava_sensor.fitfile.model import BatteryStatus, DeviceStatus
-from strava_sensor.last_activity_store import LastActivityStore
+from strava_sensor.last_activity_store import LastActivityMetadata, LastActivityStore
 
 
 def _build_device_status(serial_number: str) -> DeviceStatus:
@@ -29,9 +30,42 @@ def test_last_activity_store_roundtrip(tmp_path):
     loaded = store.load()
 
     assert loaded is not None
-    assert loaded.activity_id == 321
+    assert loaded.updated_at is not None
+    assert loaded.last_activity_id == 321
+    assert loaded.last_activity_recorded_at is not None
+    assert loaded.last_activity_device_serials == ['1234']
     assert len(loaded.devices) == 1
     assert loaded.devices[0].serial_number == '1234'
+
+
+def test_last_activity_store_merges_devices_across_saves(tmp_path):
+    store = LastActivityStore(tmp_path / 'last-activity.json')
+    device_a = _build_device_status('1234')
+    device_b = _build_device_status('9876')
+
+    store.save(activity_id=1, devices=[device_a])
+    store.save(activity_id=2, devices=[device_b])
+
+    loaded = store.load()
+    assert loaded is not None
+    assert [device.serial_number for device in loaded.devices] == ['1234', '9876']
+    assert loaded.last_activity_id == 2
+    assert loaded.last_activity_device_serials == ['9876']
+
+
+def test_last_activity_store_updates_existing_device_on_save(tmp_path):
+    store = LastActivityStore(tmp_path / 'last-activity.json')
+    device = _build_device_status('1234')
+    updated_device = device.model_copy(update={'battery_level': 17})
+
+    store.save(activity_id=1, devices=[device])
+    store.save(activity_id=2, devices=[updated_device])
+
+    loaded = store.load()
+    assert loaded is not None
+    assert len(loaded.devices) == 1
+    assert loaded.devices[0].serial_number == '1234'
+    assert loaded.devices[0].battery_level == 17
 
 
 def test_last_activity_store_invalid_json_returns_none(tmp_path):
@@ -40,3 +74,42 @@ def test_last_activity_store_invalid_json_returns_none(tmp_path):
     store = LastActivityStore(path)
 
     assert store.load() is None
+
+
+def test_last_activity_store_loads_legacy_activity_payload(tmp_path):
+    path = tmp_path / 'last-activity.json'
+    legacy = LastActivityMetadata(
+        activity_id=321,
+        recorded_at=datetime.datetime(2026, 2, 7, 20, 35, tzinfo=datetime.UTC),
+        devices=[_build_device_status('1234')],
+    )
+    path.write_text(json.dumps(legacy.model_dump(mode='json')), encoding='utf-8')
+    store = LastActivityStore(path)
+
+    loaded = store.load()
+
+    assert loaded is not None
+    assert loaded.updated_at.isoformat() == '2026-02-07T20:35:00+00:00'
+    assert loaded.last_activity_id is None
+    assert loaded.last_activity_recorded_at is None
+    assert loaded.last_activity_device_serials == []
+    assert len(loaded.devices) == 1
+    assert loaded.devices[0].serial_number == '1234'
+
+
+def test_last_activity_store_loads_sensor_payload_without_last_activity_fields(tmp_path):
+    path = tmp_path / 'last-activity.json'
+    payload = {
+        'updated_at': '2026-02-07T20:36:00Z',
+        'devices': [_build_device_status('1234').model_dump(mode='json')],
+    }
+    path.write_text(json.dumps(payload), encoding='utf-8')
+    store = LastActivityStore(path)
+
+    loaded = store.load()
+
+    assert loaded is not None
+    assert loaded.updated_at.isoformat() == '2026-02-07T20:36:00+00:00'
+    assert loaded.last_activity_id is None
+    assert loaded.last_activity_recorded_at is None
+    assert loaded.last_activity_device_serials == []

--- a/tests/test_status_page.py
+++ b/tests/test_status_page.py
@@ -1,7 +1,7 @@
 import datetime
 
 from strava_sensor.fitfile.model import BatteryStatus, DeviceStatus
-from strava_sensor.last_activity_store import LastActivityMetadata
+from strava_sensor.last_activity_store import PersistedSensorState
 from strava_sensor.ui import status_page
 from strava_sensor.ui.status_page import StatusViewModel
 
@@ -25,9 +25,11 @@ def _snapshot() -> dict[str, object]:
 def test_status_view_model_shows_persisted_last_activity_metadata(monkeypatch):
     monkeypatch.setattr(status_page.runtime_state, 'snapshot', _snapshot)
 
-    metadata = LastActivityMetadata(
-        activity_id=987,
-        recorded_at=datetime.datetime(2026, 2, 7, 20, 35, tzinfo=datetime.UTC),
+    metadata = PersistedSensorState(
+        updated_at=datetime.datetime(2026, 2, 7, 20, 35, tzinfo=datetime.UTC),
+        last_activity_id=987,
+        last_activity_recorded_at=datetime.datetime(2026, 2, 7, 20, 35, tzinfo=datetime.UTC),
+        last_activity_device_serials=['1234'],
         devices=[
             DeviceStatus(
                 device_index=1,
@@ -43,36 +45,63 @@ def test_status_view_model_shows_persisted_last_activity_metadata(monkeypatch):
                 hardware_version='A',
                 garmin_product='rtl516',
                 antplus_device_type='bike_light',
-            )
+            ),
+            DeviceStatus(
+                device_index=2,
+                device_type='heart_rate',
+                serial_number='5678',
+                product='hrm-pro',
+                battery_voltage=3.75,
+                battery_status=BatteryStatus.OK,
+                battery_level=45,
+                manufacturer='garmin',
+                source_type='antplus',
+                software_version='2.00',
+                hardware_version='B',
+                garmin_product='hrm-pro',
+                antplus_device_type='heart_rate',
+            ),
         ],
     )
 
-    def load_metadata() -> LastActivityMetadata | None:
+    def load_metadata() -> PersistedSensorState | None:
         return metadata
 
-    model = StatusViewModel(last_activity_loader=load_metadata)
+    model = StatusViewModel(persisted_sensor_loader=load_metadata)
     model.update()
 
-    assert model.last_persisted_activity_id == '987'
-    assert model.last_persisted_device_count == '1'
-    assert len(model.last_persisted_devices) == 1
-    device = model.last_persisted_devices[0]
-    assert device.serial_number == '1234'
-    assert device.battery_level == '87%'
-    assert device.battery_status == 'good'
-    assert device.battery_voltage == '5.040 V'
+    assert model.persisted_sensor_updated_at == '2026-02-07T20:35:00+00:00'
+    assert model.persisted_sensor_count == '2'
+    assert model.persisted_last_activity_id == '987'
+    assert model.persisted_last_activity_time == '2026-02-07T20:35:00+00:00'
+    assert len(model.persisted_sensors) == 2
+    latest_device = next(
+        device for device in model.persisted_sensors if device.serial_number == '1234'
+    )
+    assert latest_device.battery_level == '87%'
+    assert latest_device.battery_status == 'good'
+    assert latest_device.battery_voltage == '5.040 V'
+    assert latest_device.last_activity_marker == 'last activity'
+    assert latest_device.last_activity_marker_color == 'positive'
+
+    older_device = next(
+        device for device in model.persisted_sensors if device.serial_number == '5678'
+    )
+    assert older_device.last_activity_marker == 'known (older)'
+    assert older_device.last_activity_marker_color == 'grey'
 
 
 def test_status_view_model_handles_missing_persisted_activity(monkeypatch):
     monkeypatch.setattr(status_page.runtime_state, 'snapshot', _snapshot)
 
-    def load_metadata() -> LastActivityMetadata | None:
+    def load_metadata() -> PersistedSensorState | None:
         return None
 
-    model = StatusViewModel(last_activity_loader=load_metadata)
+    model = StatusViewModel(persisted_sensor_loader=load_metadata)
     model.update()
 
-    assert model.last_persisted_activity_id == '—'
-    assert model.last_persisted_recorded_at == '—'
-    assert model.last_persisted_device_count == '—'
-    assert model.last_persisted_devices == []
+    assert model.persisted_sensor_updated_at == '—'
+    assert model.persisted_sensor_count == '—'
+    assert model.persisted_last_activity_id == '—'
+    assert model.persisted_last_activity_time == '—'
+    assert model.persisted_sensors == []

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -425,7 +425,7 @@ async def test_reconnect_mqtt_republishes_persisted_metadata(monkeypatch):
     saved_records = []
 
     class FakeMetadata:
-        activity_id = 99
+        updated_at = '2026-02-07T20:35:00Z'
         devices = [device]
 
     class FakeStore:


### PR DESCRIPTION
We want to keep all known sensors in state not just the ones from the
last activity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added last activity status indicators to device displays with color-coded visual markers
  * Enhanced status page with additional sensor metadata including update timestamps and device counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->