### PR TITLE
Treat FIT `device_index` as opaque string and simplify parsing

### DIFF
--- a/src/strava_sensor/fitfile/fitfile.py
+++ b/src/strava_sensor/fitfile/fitfile.py
@@ -97,14 +97,14 @@ class FitFile:
     def get_devices_status(self) -> list[DeviceStatus]:
         device_info = self.messages.get(MessageType.DEVICE_INFO.value, [])
 
-        serial_number_by_device_index: dict[t.Any, str] = {}
+        serial_number_by_device_index: dict[str, str] = {}
         for message in device_info:
             serial_number = message.get('serial_number')
             if not serial_number:
                 continue
-            serial_number_by_device_index[message.get('device_index')] = str(serial_number)
+            serial_number_by_device_index[str(message.get('device_index'))] = str(serial_number)
 
-        device_status_by_index: dict[int, DeviceStatus] = {}
+        device_status_by_index: dict[str, DeviceStatus] = {}
 
         for message in device_info:
             if not message.get('battery_status'):
@@ -112,10 +112,11 @@ class FitFile:
 
             # Strip message of int keys which break pydantic validation
             message_stripped = {k: v for k, v in message.items() if isinstance(k, str)}
+            message_stripped['device_index'] = str(message_stripped.get('device_index'))
 
             if not message_stripped.get('serial_number'):
                 message_stripped['serial_number'] = serial_number_by_device_index.get(
-                    message_stripped.get('device_index')
+                    message_stripped['device_index']
                 )
 
             try:

--- a/src/strava_sensor/fitfile/model.py
+++ b/src/strava_sensor/fitfile/model.py
@@ -38,7 +38,7 @@ class DeviceStatus(pydantic.BaseModel):
         'coerce_numbers_to_str': True,
     }
 
-    device_index: int
+    device_index: str
     device_type: str
     serial_number: str
     product: str

--- a/tests/test_fitfile.py
+++ b/tests/test_fitfile.py
@@ -70,7 +70,7 @@ def test__fitfile__devices_status(fitfile_fixture):
     assert len(device_statuses) == 3
 
     bike_radar = device_statuses[0]
-    assert bike_radar.device_index == 5
+    assert bike_radar.device_index == '5'
     assert bike_radar.device_type == 'bike_radar'
     assert bike_radar.serial_number == '3359471441'
     assert bike_radar.product == 'varia rtl516'
@@ -83,7 +83,7 @@ def test__fitfile__devices_status(fitfile_fixture):
     assert bike_radar.hardware_version == '66'
 
     bike_power = device_statuses[1]
-    assert bike_power.device_index == 2
+    assert bike_power.device_index == '2'
     assert bike_power.device_type == 'bike_power'
     assert bike_power.serial_number == '7891445'
     assert bike_power.product == 'assioma pro mx-2 spd'
@@ -96,7 +96,7 @@ def test__fitfile__devices_status(fitfile_fixture):
     assert bike_power.hardware_version == '7'
 
     bike_speed = device_statuses[2]
-    assert bike_speed.device_index == 8
+    assert bike_speed.device_index == '8'
     assert bike_speed.device_type == 'bike_speed'
     assert bike_speed.serial_number == '11699632'
     assert bike_speed.product == 'bsm'

--- a/tests/test_last_activity_store.py
+++ b/tests/test_last_activity_store.py
@@ -7,7 +7,7 @@ from strava_sensor.last_activity_store import LastActivityMetadata, LastActivity
 
 def _build_device_status(serial_number: str) -> DeviceStatus:
     return DeviceStatus(
-        device_index=0,
+        device_index='0',
         device_type='radar',
         serial_number=serial_number,
         product='rtl516',

--- a/tests/test_status_page.py
+++ b/tests/test_status_page.py
@@ -32,7 +32,7 @@ def test_status_view_model_shows_persisted_last_activity_metadata(monkeypatch):
         last_activity_device_serials=['1234'],
         devices=[
             DeviceStatus(
-                device_index=1,
+                device_index='1',
                 device_type='bike_light',
                 serial_number='1234',
                 product='rtl516',
@@ -47,7 +47,7 @@ def test_status_view_model_shows_persisted_last_activity_metadata(monkeypatch):
                 antplus_device_type='bike_light',
             ),
             DeviceStatus(
-                device_index=2,
+                device_index='2',
                 device_type='heart_rate',
                 serial_number='5678',
                 product='hrm-pro',


### PR DESCRIPTION
### Motivation
- `device_index` is treated as an opaque identifier and may appear as non-int types, so code should consistently handle it as a string to avoid unnecessary normalization and runtime checks. 
- Remove the indirection and noise introduced by the `_normalize_device_index` helper and redundant `isinstance` guards.

### Description
- Change `DeviceStatus.device_index` type to `str` in `src/strava_sensor/fitfile/model.py` to treat the index as an opaque string. 
- Simplify `FitFile.get_devices_status()` in `src/strava_sensor/fitfile/fitfile.py` by stringifying `device_index` with `str(...)`, removing the `_normalize_device_index` helper, and using the stringified index for serial-number fallback and de-duplication. 
- Update tests to expect string `device_index` values: `tests/test_fitfile.py`, `tests/test_last_activity_store.py`, and `tests/test_status_page.py` were adjusted accordingly. 

### Testing
- Ran `uv run ./scripts/run-all-checks.sh`, which executes the pre-commit hooks, `pyright`, `ruff` checks/formatting, and `pytest`; the run completed successfully. 
- All automated tests included in the repository passed under the above check script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b8c256904832caf978189baf35c51)