### PR TITLE
Support multi-battery aux parsing and normalize device_index to string

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Environment variables documented in README.md
 
 # renovate: datasource=github-releases packageName=astral-sh/uv
-ARG UV_VERSION=0.10.0
+ARG UV_VERSION=0.10.1
 
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
 

--- a/src/strava_sensor/fitfile/fitfile.py
+++ b/src/strava_sensor/fitfile/fitfile.py
@@ -96,15 +96,54 @@ class FitFile:
 
     def get_devices_status(self) -> list[DeviceStatus]:
         device_info = self.messages.get(MessageType.DEVICE_INFO.value, [])
+        aux_battery_info = self.messages.get(MessageType.DEVICE_AUX_BATTERY_INFO.value, [])
 
-        device_status_by_index: dict[int, DeviceStatus] = {}
+        serial_number_by_device_index: dict[str, str] = {}
+        for message in device_info:
+            serial_number = message.get('serial_number')
+            if not serial_number:
+                continue
+            serial_number_by_device_index[str(message.get('device_index', ''))] = str(serial_number)
+
+        latest_device_metadata_by_index: dict[
+            str, tuple[datetime.datetime | None, dict[str, t.Any]]
+        ] = {}
+        device_status_by_index: dict[str, DeviceStatus] = {}
+        aux_status_by_key: dict[tuple[str, int], tuple[datetime.datetime | None, DeviceStatus]] = {}
 
         for message in device_info:
-            if not message.get('battery_status'):
-                continue
-
             # Strip message of int keys which break pydantic validation
             message_stripped = {k: v for k, v in message.items() if isinstance(k, str)}
+            device_index_raw = message_stripped.get('device_index')
+            if device_index_raw is None:
+                continue
+
+            device_index = str(device_index_raw)
+            message_stripped['device_index'] = device_index
+
+            if not message_stripped.get('serial_number'):
+                message_stripped['serial_number'] = serial_number_by_device_index.get(device_index)
+
+            required_metadata_fields = ('serial_number', 'product', 'manufacturer', 'source_type')
+            has_required_metadata = all(
+                field in message_stripped and message_stripped[field] is not None
+                for field in required_metadata_fields
+            )
+            if has_required_metadata:
+                timestamp = message_stripped.get('timestamp')
+                if not isinstance(timestamp, datetime.datetime):
+                    timestamp = None
+
+                previous_entry = latest_device_metadata_by_index.get(device_index)
+                if (
+                    previous_entry is None
+                    or previous_entry[0] is None
+                    or (timestamp is not None and previous_entry[0] <= timestamp)
+                ):
+                    latest_device_metadata_by_index[device_index] = (timestamp, message_stripped)
+
+            if not message.get('battery_status'):
+                continue
 
             try:
                 device_status = DeviceStatus.model_validate(message_stripped)
@@ -117,4 +156,62 @@ class FitFile:
                 continue
             device_status_by_index[device_status.device_index] = device_status
 
-        return list(device_status_by_index.values())
+        for message in aux_battery_info:
+            battery_identifier = message.get('battery_identifier')
+            if not isinstance(battery_identifier, int):
+                continue
+
+            device_index_raw = message.get('device_index')
+            if device_index_raw is None:
+                continue
+            device_index = str(device_index_raw)
+
+            metadata_entry = latest_device_metadata_by_index.get(device_index)
+            if metadata_entry is None:
+                _logger.warning(
+                    'Skipping aux battery message because no matching device metadata was found: %s',
+                    message,
+                )
+                continue
+            _, base_message = metadata_entry
+
+            message_stripped = {
+                k: v for k, v in message.items() if isinstance(k, str) and k != 'timestamp'
+            }
+            message_stripped['device_index'] = device_index
+            merged_message = {
+                **base_message,
+                **message_stripped,
+            }
+
+            try:
+                device_status = DeviceStatus.model_validate(merged_message)
+            except pydantic.ValidationError as exc:
+                _logger.warning(
+                    'Skipping invalid device_aux_battery_info message: %s (message=%s)',
+                    exc,
+                    merged_message,
+                )
+                continue
+
+            timestamp = message.get('timestamp')
+            if not isinstance(timestamp, datetime.datetime):
+                timestamp = None
+
+            key = (device_index, battery_identifier)
+            previous_status = aux_status_by_key.get(key)
+            if (
+                previous_status is None
+                or previous_status[0] is None
+                or (timestamp is not None and previous_status[0] <= timestamp)
+            ):
+                aux_status_by_key[key] = (timestamp, device_status)
+
+        for device_index, device_status in device_status_by_index.items():
+            aux_battery_exists = any(
+                aux_device_index == device_index for aux_device_index, _ in aux_status_by_key
+            )
+            if not aux_battery_exists:
+                aux_status_by_key[(device_index, 0)] = (None, device_status)
+
+        return [status for _, status in aux_status_by_key.values()]

--- a/src/strava_sensor/fitfile/model.py
+++ b/src/strava_sensor/fitfile/model.py
@@ -38,13 +38,14 @@ class DeviceStatus(pydantic.BaseModel):
         'coerce_numbers_to_str': True,
     }
 
-    device_index: int
+    device_index: str
     device_type: str
     serial_number: str
     product: str
     battery_voltage: float | None = None
     battery_status: BatteryStatus
     battery_level: int | None = None
+    battery_identifier: int | None = None
     manufacturer: str
     source_type: str
     software_version: str | None = None
@@ -81,18 +82,26 @@ class DeviceStatus(pydantic.BaseModel):
             True if both publishes succeeded, False otherwise
         """
         # Publish device status
-        mqtt_path = f'strava/{self.serial_number}/status'
+        device_serial = self.serial_number
+        if self.battery_identifier is not None:
+            device_serial = f'{device_serial}_{self.battery_identifier}'
+
+        mqtt_path = f'strava/{device_serial}/status'
         status_success = mqtt_client.publish(mqtt_path, self.model_dump_json())
 
         # Publish home assistant discovery information
-        device_id = f'strava-{self.serial_number}'
+        device_id = f'strava-{device_serial}'
+        device_name = f'Strava {self.device_type} {self.serial_number}'
+        if self.battery_identifier is not None:
+            device_name = f'{device_name} (battery {self.battery_identifier})'
+
         payload: dict[str, t.Any] = {
             'dev': {
                 'ids': device_id,
-                'name': f'Strava {self.device_type} {self.serial_number}',
+                'name': device_name,
                 'mf': self.manufacturer,
                 'mdl': f'{self.product}',
-                'sn': self.serial_number,
+                'sn': device_serial,
                 'sw': self.software_version,
             },
             'o': {
@@ -132,7 +141,7 @@ class DeviceStatus(pydantic.BaseModel):
         if self.hardware_version:
             payload['dev']['hw'] = self.hardware_version
 
-        discovery_topic = f'homeassistant/device/strava-{self.serial_number}/config'
+        discovery_topic = f'homeassistant/device/{device_id}/config'
         _logger.debug('Publishing discovery topic: %s', discovery_topic)
         discovery_success = mqtt_client.publish(discovery_topic, json.dumps(payload))
 

--- a/tests/test_fitfile.py
+++ b/tests/test_fitfile.py
@@ -67,10 +67,10 @@ def test__fitfile__parse_corrupted_invalid_activity_file(fitfile_fixture):
 
 def test__fitfile__devices_status(fitfile_fixture):
     device_statuses = fitfile_fixture.get_devices_status()
-    assert len(device_statuses) == 3
+    assert len(device_statuses) == 4
 
-    bike_radar = device_statuses[0]
-    assert bike_radar.device_index == 5
+    bike_radar = [device for device in device_statuses if device.device_type == 'bike_radar'][0]
+    assert bike_radar.device_index == '5'
     assert bike_radar.device_type == 'bike_radar'
     assert bike_radar.serial_number == '3359471441'
     assert bike_radar.product == 'varia rtl516'
@@ -82,21 +82,34 @@ def test__fitfile__devices_status(fitfile_fixture):
     assert bike_radar.software_version == '3.34'
     assert bike_radar.hardware_version == '66'
 
-    bike_power = device_statuses[1]
-    assert bike_power.device_index == 2
-    assert bike_power.device_type == 'bike_power'
-    assert bike_power.serial_number == '7891445'
-    assert bike_power.product == 'assioma pro mx-2 spd'
-    assert bike_power.battery_voltage == 3.74609375
-    assert bike_power.battery_status == 'low'
-    assert bike_power.battery_level is None
-    assert bike_power.manufacturer == 'favero_electronics'
-    assert bike_power.source_type == 'antplus'
-    assert bike_power.software_version == '6.1'
-    assert bike_power.hardware_version == '7'
+    bike_power_primary = [
+        device
+        for device in device_statuses
+        if device.device_type == 'bike_power' and device.battery_identifier == 0
+    ][0]
+    assert bike_power_primary.device_index == '2'
+    assert bike_power_primary.device_type == 'bike_power'
+    assert bike_power_primary.serial_number == '7891445'
+    assert bike_power_primary.product == 'assioma pro mx-2 spd'
+    assert bike_power_primary.battery_voltage == 3.74609375
+    assert bike_power_primary.battery_status == 'low'
+    assert bike_power_primary.battery_level is None
+    assert bike_power_primary.battery_identifier == 0
+    assert bike_power_primary.manufacturer == 'favero_electronics'
+    assert bike_power_primary.source_type == 'antplus'
+    assert bike_power_primary.software_version == '6.1'
+    assert bike_power_primary.hardware_version == '7'
 
-    bike_speed = device_statuses[2]
-    assert bike_speed.device_index == 8
+    bike_power_secondary = [
+        device
+        for device in device_statuses
+        if device.device_type == 'bike_power' and device.battery_identifier == 1
+    ][0]
+    assert bike_power_secondary.battery_voltage == 3.75390625
+    assert bike_power_secondary.battery_status == 'low'
+
+    bike_speed = [device for device in device_statuses if device.device_type == 'bike_speed'][0]
+    assert bike_speed.device_index == '8'
     assert bike_speed.device_type == 'bike_speed'
     assert bike_speed.serial_number == '11699632'
     assert bike_speed.product == 'bsm'
@@ -122,6 +135,52 @@ def test__fitfile__devices_status_ignores_invalid_device_info_message(fitfile_fi
     )
 
     device_statuses = fitfile.get_devices_status()
-    assert len(device_statuses) == 3
+    assert len(device_statuses) == 4
     bike_power = [device for device in device_statuses if device.device_type == 'bike_power'][0]
     assert bike_power.serial_number == '7891445'
+
+
+def test__fitfile__devices_status_reuses_serial_number_from_same_device_index(fitfile_fixture):
+    fitfile = copy.deepcopy(fitfile_fixture)
+    fitfile.messages['device_info_mesgs'].append(  # type: ignore[arg-type]
+        {
+            'timestamp': datetime.datetime.now(datetime.UTC),
+            'device_index': 2,
+            'device_type': 'bike_power',
+            'product': 22,
+            'battery_status': 'new',
+            'battery_voltage': 4.0,
+            'manufacturer': 'favero_electronics',
+            'source_type': 'antplus',
+            # serial_number intentionally missing from latest battery sample
+        }
+    )
+
+    device_statuses = fitfile.get_devices_status()
+    bike_power = [
+        device
+        for device in device_statuses
+        if device.device_type == 'bike_power' and device.battery_identifier == 0
+    ][0]
+    assert bike_power.serial_number == '7891445'
+    assert bike_power.battery_status == 'low'
+    assert bike_power.battery_voltage == 3.74609375
+
+
+def test__fitfile__devices_status_uses_device_metadata_for_aux_batteries(fitfile_fixture):
+    fitfile = copy.deepcopy(fitfile_fixture)
+
+    for message in fitfile.messages['device_info_mesgs']:  # type: ignore[index]
+        if message.get('device_index') == 2:
+            message.pop('battery_status', None)
+            message.pop('battery_voltage', None)
+
+    device_statuses = fitfile.get_devices_status()
+    bike_power_statuses = [
+        device for device in device_statuses if device.device_type == 'bike_power'
+    ]
+
+    assert len(bike_power_statuses) == 2
+    assert {device.battery_identifier for device in bike_power_statuses} == {0, 1}
+    assert {device.battery_voltage for device in bike_power_statuses} == {3.74609375, 3.75390625}
+    assert all(device.serial_number == '7891445' for device in bike_power_statuses)

--- a/tests/test_last_activity_store.py
+++ b/tests/test_last_activity_store.py
@@ -7,7 +7,7 @@ from strava_sensor.last_activity_store import LastActivityMetadata, LastActivity
 
 def _build_device_status(serial_number: str) -> DeviceStatus:
     return DeviceStatus(
-        device_index=0,
+        device_index='0',
         device_type='radar',
         serial_number=serial_number,
         product='rtl516',

--- a/tests/test_status_page.py
+++ b/tests/test_status_page.py
@@ -32,7 +32,7 @@ def test_status_view_model_shows_persisted_last_activity_metadata(monkeypatch):
         last_activity_device_serials=['1234'],
         devices=[
             DeviceStatus(
-                device_index=1,
+                device_index='1',
                 device_type='bike_light',
                 serial_number='1234',
                 product='rtl516',
@@ -47,7 +47,7 @@ def test_status_view_model_shows_persisted_last_activity_metadata(monkeypatch):
                 antplus_device_type='bike_light',
             ),
             DeviceStatus(
-                device_index=2,
+                device_index='2',
                 device_type='heart_rate',
                 serial_number='5678',
                 product='hrm-pro',


### PR DESCRIPTION
### Motivation
- Improve FIT parsing to correctly handle devices with multiple batteries reported via `device_aux_battery_info_mesgs` and to tolerate partially-populated `device_info` messages.
- Align model typing and MQTT identity so separate batteries publish distinct Home Assistant discovery/state entities.
- Integrate upstream changes and resolve the conflicts introduced by the multi-battery work.

### Description
- Refactor `FitFile.get_devices_status()` to normalize `device_index` to a string, remember latest valid device metadata per device index, merge `device_aux_battery_info_mesgs` with that metadata, and keep the latest status per `(device_index, battery_identifier)` by timestamp.
- Extend `DeviceStatus` in `src/strava_sensor/fitfile/model.py` to use `device_index: str` and add `battery_identifier: int | None`, and update MQTT publishing to include `battery_identifier` in topic, discovery ID and device name when present.
- Update tests in `tests/test_fitfile.py` and other affected tests to validate dual-battery extraction, serial-number reuse for incomplete records, metadata-based aux reconstruction, and the string-typed `device_index` expectations.
- Bumped container base tool version in `Dockerfile` (astral `uv` ARG) to match upstream changes.

### Testing
- Ran project checks with `uv run ./scripts/run-all-checks.sh` which executed pre-commit hooks, static checks (`pyright`, `ruff`), and the test suite automatically, and the run completed successfully.
- All automated tests (including `pytest` for the updated FIT parsing tests) passed during the checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b85eeeadc832cb1c16e0c68baef5f)